### PR TITLE
Added support for toree 1.0

### DIFF
--- a/spark-kernel/build.gradle
+++ b/spark-kernel/build.gradle
@@ -39,6 +39,7 @@ configurations {
 	
  dependencies {
     compile name: 'kernel-assembly-0.1.5-SNAPSHOT'
+    compile name: 'toree-kernel-assembly-0.1.0.dev4-SNAPSHOT'
     compile 'org.apache.spark:spark-repl_2.10:1.5.2' 
     compile project(':data')
     compile project(':core')

--- a/spark-kernel/src/main/scala/org/apache/toree/magic/brunel/package.scala
+++ b/spark-kernel/src/main/scala/org/apache/toree/magic/brunel/package.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2015 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.toree.magic
+
+import org.apache.toree.kernel.api.Kernel
+import org.apache.spark.repl.SparkIMain
+
+package object brunel {
+
+  private var _the_kernel: Kernel = _
+
+  def initWidgets(implicit kernel: Kernel): Unit = {
+    _the_kernel = kernel
+  }
+
+  def getKernel: Kernel = {
+    _the_kernel
+  }
+
+  def sparkIMain: SparkIMain = {
+    val sparkIMainMethod = getKernel.interpreter.getClass.getMethod("sparkIMain")
+    val sparkIMain = sparkIMainMethod.invoke(getKernel.interpreter).asInstanceOf[org.apache.spark.repl.SparkIMain]
+    sparkIMain
+  }
+}

--- a/spark-kernel/src/main/scala/org/apache/toree/magic/builtin/Brunel.scala
+++ b/spark-kernel/src/main/scala/org/apache/toree/magic/builtin/Brunel.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2015 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.toree.magic.builtin
+
+import org.apache.toree.kernel.protocol.v5.MIMEType
+import org.apache.toree.magic.dependencies.IncludeInterpreter
+import org.apache.toree.magic.{CellMagic, CellMagicOutput}
+import org.apache.spark.sql.DataFrame
+
+class Brunel extends CellMagic with IncludeInterpreter {
+
+  override def execute(code: String) = {
+    val line = if (code contains "%%") {
+      code.replace("\n", " ")
+    } else {
+      code
+    }
+
+
+    var width: Int = 500
+    var height: Int = 400
+    var action: String = null
+    var extras: String = null
+    var dataFrameNames: Array[String] = null
+    var data: Option[DataFrame] = None
+
+    val parts = line.split("::")
+    if (parts.length > 2) {
+      throw new IllegalArgumentException("Only one ':' allowed in brunel magic. Format is 'ACTION : key=value, ...'")
+    }
+
+    if (parts.length > 0) {
+      action = parts(0).trim
+      dataFrameNames = org.brunel.scala.Brunel.getDatasetNames(action)
+      if (dataFrameNames.length > 0) cacheDataFrames(dataFrameNames);
+    }
+
+    if (parts.length > 1) {
+
+      extras = parts(1).trim
+      val dataName = findTerm("data", extras, null)
+      if (dataName != null) {
+        try {
+          data = getData(dataName)
+          if (!data.nonEmpty) throw new IllegalArgumentException("Requested DataFrame: " + dataName + " was not found.")
+        } catch {
+          case e: Exception => e.printStackTrace
+        }
+      }
+      width = findTerm("width", extras, width.toString).toInt
+      height = findTerm("height", extras, height.toString).toInt
+    }
+
+    val visId = "visid" + java.util.UUID.randomUUID.toString
+    val controlsId = "controlsId" + java.util.UUID.randomUUID.toString
+    val brunelOutput = org.brunel.scala.Brunel.create(data.orNull, action, width, height, visId, controlsId)
+    val version = org.brunel.scala.Brunel.brunelVersion
+
+    val d3js =  brunelOutput.js
+    val d3dynamicCss = brunelOutput.css
+
+    val html =
+
+      s"""
+         <link rel="stylesheet" type="text/css" href="http://www.brunelvis.org/js/brunel.$version.css" charset="utf-8">
+         <link rel="stylesheet" type="text/css" href="http://www.brunelvis.org/js/sumoselect.css" charset="utf-8">
+         <style> $d3dynamicCss </style>
+         <div id="$controlsId" class="brunel"/>
+         |<svg id="$visId" width="$width" height="$height"></svg>
+         |
+         |<script>
+         |require.config({
+            waitSeconds: 60,
+            paths: {
+                'd3': '//cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min',
+                'brunel' : 'http://www.brunelvis.org/js/brunel.$version.min',
+                'brunelControls' : 'http://www.brunelvis.org/js/brunel.controls.$version.min'
+            },
+
+            shim: {
+               'brunel' : {
+                    exports: 'BrunelD3',
+                    init: function() {
+                       return {
+                         BrunelD3 : BrunelD3,
+                         BrunelData : BrunelData
+                      }
+                    }
+                },
+               'brunelControls' : {
+                    exports: 'BrunelEventHandlers',
+                    init: function() {
+                       return {
+                         BrunelEventHandlers: BrunelEventHandlers,
+                         BrunelJQueryControlFactory: BrunelJQueryControlFactory
+                      }
+                    }
+                }
+
+            }
+
+        });
+
+        require(["d3"], function(d3) {
+        require(["brunel", "brunelControls"], function(brunel, brunelControls) {
+
+            $d3js
+            ""
+        });
+        });
+        </script>""".stripMargin
+
+    CellMagicOutput(MIMEType.TextHtml -> html)
+  }
+
+  def cacheDataFrames(datasetNames: Array[String]) = {
+    for (name <- datasetNames) {
+      val data = getData(name)
+      if (data.nonEmpty) {
+        org.brunel.scala.Brunel.cacheData(name, data.get)
+      }
+    }
+  }
+
+  def findTerm(key: String, str: String, default: String): String = {
+    for (expr <- str.split(",")) {
+      val terms = expr.split("=")
+      if (terms.length != 2) {
+        throw new IllegalArgumentException("Bad format for key=value pair: " + expr)
+      }
+      if (key == terms(0).trim.toLowerCase) {
+        return terms(1).trim
+      }
+    }
+    default
+  }
+
+  def getData(dataFrameName: String): Option[DataFrame] = {
+    interpreter.read(dataFrameName) match {
+      case Some(df) =>
+        Some(df.asInstanceOf[DataFrame])
+      case _ =>
+        None
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes #54 while retaining backward compatibility with spark-kernel 1.5+

Not very elegant, just copied the code and refactored it. I am not sure if there is a nice way to share the code without creating cross-dependencies on the spark-kernel / toree version